### PR TITLE
Fix typo in the description.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "json-api-normalizer",
   "version": "0.1.0",
-  "description": "JSON API response normaliser",
+  "description": "JSON API response normalizer",
   "main": "dist/bundle.js",
   "scripts": {
     "build": "NODE_ENV=production webpack -p",


### PR DESCRIPTION
Very nice utility!

Just fix a typo: `normaliser` -> `normalizer`