### PR TITLE
Sore links on metaObject when filterEndpoint is set to false

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -120,6 +120,7 @@ function extractMetaData(json, endpoint, { camelizeKeys, filterEndpoint }) {
     metaObject.data = meta;
 
     if (json.links) {
+      metaObject.links = json.links;
       ret.meta[doFilterEndpoint(endpoint)].links = json.links;
     }
 

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -347,6 +347,10 @@ describe('meta', () => {
               }
             }
           }],
+          links: {
+            next: "http://example.com/api/v1/posts/friends_feed/superyuri?page[cursor]=5037",
+            first: "http://api.postie.loc/v1/posts/friends_feed/superyuri?page[cursor]=0"
+          },
         },
         links: {
           next: "http://example.com/api/v1/posts/friends_feed/superyuri?page[cursor]=5037",


### PR DESCRIPTION
Fixes #6.

Update tests.