### PR TITLE
support for resource object meta information

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -75,6 +75,11 @@ function extractEntities(json, { camelizeKeys }) {
       ret[type][elem.id].relationships =
         extractRelationships(elem.relationships, { camelizeKeys });
     }
+    
+    if (elem.meta) {
+      ret[type][elem.id].meta = elem.meta;
+    }
+
   });
 
   return ret;

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -14,6 +14,9 @@ describe('data is normalized', () => {
         },
         links: {
           self: 'http://www.example.com/post/3'
+        },
+        meta: {
+          'like-count': 35
         }
       },
       {
@@ -40,6 +43,9 @@ describe('data is normalized', () => {
         },
         links: {
           self: 'http://www.example.com/post/3'
+        },
+        meta: {
+          'like-count': 35
         }
       },
       "4": {


### PR DESCRIPTION
resource object "meta" tag should be supported as per the [spec](http://jsonapi.org/format/#document-meta) 
#19 