### PR TITLE
Keep metadata and links even if data it not returned in the response

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -157,15 +157,15 @@ function extractMetaData(json, endpoint, { camelizeKeys, filterEndpoint }) {
     });
 
     metaObject.data = meta;
+  }
 
-    if (json.links) {
-      metaObject.links = json.links;
-      ret.meta[doFilterEndpoint(endpoint)].links = json.links;
-    }
+  if (json.links) {
+    metaObject.links = json.links;
+    ret.meta[doFilterEndpoint(endpoint)].links = json.links;
+  }
 
-    if (json.meta) {
-      metaObject.meta = json.meta;
-    }
+  if (json.meta) {
+    metaObject.meta = json.meta;
   }
 
   return ret;


### PR DESCRIPTION
JSON API spec indicates that the `data` object is optional, but `meta` and `links` can still be returned. Keep this data on the metadata object.