### PR TITLE
Camelcase links attributes

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -62,7 +62,7 @@ function extractRelationships(relationships, { camelizeKeys, camelizeTypeValues 
     }
 
     if (relationship.links) {
-      ret[name].links = relationship.links;
+      ret[name].links = camelizeKeys ? camelizeNestedKeys(relationship.links) : relationship.links;
     }
   });
   return ret;
@@ -94,7 +94,8 @@ function extractEntities(json, { camelizeKeys, camelizeTypeValues }) {
       ret[type][elem.id].links = {};
 
       keys(elem.links).forEach((key) => {
-        ret[type][elem.id].links[key] = elem.links[key];
+        const newKey = camelizeKeys ? camelCase(key) : key;
+        ret[type][elem.id].links[newKey] = elem.links[key];
       });
     }
 

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -86,6 +86,9 @@ describe('data is normalized', () => {
           meta: {
             'this-key-too': 3,
           },
+          links: {
+            this_link: 'http://link.com'
+          }
         },
       ],
     };
@@ -101,6 +104,9 @@ describe('data is normalized', () => {
           meta: {
             thisKeyToo: 3,
           },
+          links: {
+            thisLink: 'http://link.com'
+          }
         },
       },
     };
@@ -592,6 +598,62 @@ describe('relationships', () => {
 
     expect(result).to.deep.equal(output);
   });
+
+  it('camelize links', () => {
+    const json = {
+      data: [
+        {
+          type: 'post',
+          relationships: {
+            tags: {
+              data: [
+                {
+                  id: 4,
+                  type: 'tag',
+                },
+              ],
+              links: {
+                camel_case: 'http://example.com/api/v1/post/2620/tags',
+              },
+            },
+          },
+          id: 2620,
+          attributes: {
+            text: 'hello',
+          },
+        },
+      ],
+    };
+
+    const output = {
+      post: {
+        2620: {
+          type: 'post',
+          id: 2620,
+          attributes: {
+            text: 'hello',
+          },
+          relationships: {
+            tags: {
+              data: [
+                {
+                  id: 4,
+                  type: 'tag',
+                },
+              ],
+              links: {
+                camelCase: 'http://example.com/api/v1/post/2620/tags',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = normalize(json);
+
+    expect(result).to.deep.equal(output);
+  });
 });
 
 describe('meta', () => {
@@ -979,6 +1041,9 @@ describe('complex', () => {
             ],
           },
         },
+        links: {
+          post_blocks: 'http://link.com'
+        },
         type: 'post-block',
       },
       {
@@ -1038,6 +1103,9 @@ describe('complex', () => {
       2454: {
         type: 'postBlock',
         id: 2454,
+        links: {
+          post_blocks: 'http://link.com'
+        },
         attributes: {},
         relationships: {
           user: {
@@ -1146,6 +1214,9 @@ describe('complex', () => {
       2454: {
         type: 'postBlock',
         id: 2454,
+        links: {
+          postBlocks: 'http://link.com'
+        },
         attributes: {},
         relationships: {
           user: {
@@ -1254,6 +1325,9 @@ describe('complex', () => {
       2454: {
         type: 'post-block',
         id: 2454,
+        links: {
+          postBlocks: 'http://link.com'
+        },
         attributes: {},
         relationships: {
           user: {


### PR DESCRIPTION
Attributes in the `links` weren't being camelcased (both at the root level and entity level). Not sure if this was intentional?

This PR enables camelcase for these attributes if `camelizeKeys` is set.