### PR TITLE
bump Lodash dependency to 4.17.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3580,9 +3580,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "webpack-node-externals": "^1.5.4"
   },
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.15"
   }
 }


### PR DESCRIPTION
According to [Snyk vulnerability monitoring for Lodash](https://snyk.io/vuln/npm:lodash), version `4.17.11` contains a security issue that consumers of `json-api-normalizer` would like remediated.

Updating to `4.17.15` should solve this issue.

Lodash:
- [npm listing](https://www.npmjs.com/package/lodash)
- [GitHub listing](https://github.com/lodash/lodash) and [changelog](https://github.com/lodash/lodash/wiki/Changelog)