### PR TITLE
Preserve relationship.meta if relationship.data is undefined

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -55,14 +55,14 @@ function extractRelationships(relationships, { camelizeKeys, camelizeTypeValues 
       } else {
         ret[name].data = relationship.data;
       }
-
-      if (typeof relationship.meta !== 'undefined') {
-        ret[name].meta = camelizeNestedKeys(relationship.meta);
-      }
     }
 
     if (relationship.links) {
       ret[name].links = camelizeKeys ? camelizeNestedKeys(relationship.links) : relationship.links;
+    }
+
+    if (relationship.meta) {
+      ret[name].meta = camelizeKeys ? camelizeNestedKeys(relationship.meta) : relationship.meta;
     }
   });
   return ret;

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -654,6 +654,68 @@ describe('relationships', () => {
 
     expect(result).to.deep.equal(output);
   });
+
+  it('keeps meta', () => {
+    const json = {
+      data: [
+        {
+          type: 'post',
+          relationships: {
+            tags: {
+              data: [
+                {
+                  id: 4,
+                  type: 'tag',
+                },
+              ],
+              links: {
+                self: 'http://example.com/api/v1/post/2620/tags',
+              },
+              meta: {
+                count: 2
+              }
+            },
+          },
+          id: 2620,
+          attributes: {
+            text: 'hello',
+          },
+        },
+      ],
+    };
+
+    const output = {
+      post: {
+        2620: {
+          type: 'post',
+          id: 2620,
+          attributes: {
+            text: 'hello',
+          },
+          relationships: {
+            tags: {
+              data: [
+                {
+                  id: 4,
+                  type: 'tag',
+                },
+              ],
+              links: {
+                self: 'http://example.com/api/v1/post/2620/tags',
+              },
+              meta: {
+                count: 2
+              }
+            },
+          },
+        },
+      },
+    };
+
+    const result = normalize(json);
+
+    expect(result).to.deep.equal(output);
+  });
 });
 
 describe('meta', () => {


### PR DESCRIPTION
@yury-dymov if `relationship.data` is not defined, then `relationship.meta` is stripped from the normalized data. The json api spec states that `a “relationship object” must contain at least one of the following: links, data, meta`.  None are dependent on each other.  

https://jsonapi.org/format/#document-resource-object-relationships